### PR TITLE
Implement tree fold in trace replay

### DIFF
--- a/src/tools/manage_actions/raw_trace_actions_to_replayable.ml
+++ b/src/tools/manage_actions/raw_trace_actions_to_replayable.ml
@@ -593,7 +593,7 @@ let event_infos =
         to_v1 =
           (fun ids -> Def1.Patch_context_exit (scopec ids c, scopec ids c'));
       }
-  | List _ ->
+  | List ((_ctxt, _offset_opt, _length_opt), _trees) ->
       (* Since there are no occurences of it in the Raw trace, and since this is
          tricky to implement, let's not implement it yet to avoid introducing
          non-covered bugs *)

--- a/src/tools/manage_actions/raw_trace_actions_to_replayable.ml
+++ b/src/tools/manage_actions/raw_trace_actions_to_replayable.ml
@@ -379,10 +379,34 @@ let event_infos =
                 Def1.Tree.Remove ((scopet ids t, x), scopet ids t') |> to_tree);
           }
       | List _ -> (* see List for rationale *) crash
-      | Fold_start _ -> (* see List for rationale *) crash
-      | Fold_step_enter _ -> crash
-      | Fold_step_exit _ -> crash
-      | Fold_end _ -> crash)
+      | Fold_start (x, tree, key) ->
+          {
+            rank = `Use;
+            tracker_ids = ([ tree ], [], []);
+            to_v1 =
+              (fun ids ->
+                Def1.Tree.Fold_start (x, scopet ids tree, key) |> to_tree);
+          }
+      | Fold_step_enter t ->
+          {
+            rank = `Use;
+            tracker_ids = ([ t ], [], []);
+            to_v1 =
+              (fun ids -> Def1.Tree.Fold_step_enter (scopet ids t) |> to_tree);
+          }
+      | Fold_step_exit t ->
+          {
+            rank = `Use;
+            tracker_ids = ([ t ], [], []);
+            to_v1 =
+              (fun ids -> Def1.Tree.Fold_step_exit (scopet ids t) |> to_tree);
+          }
+      | Fold_end i ->
+          {
+            rank = `Use;
+            tracker_ids = ([], [], []);
+            to_v1 = (fun _ -> Def1.Tree.Fold_end i |> to_tree);
+          })
   | Find_tree ((c, x), t') ->
       {
         rank = `Use;

--- a/src/trace/raw_actions.ml
+++ b/src/trace/raw_actions.ml
@@ -226,6 +226,9 @@ module V0 = struct
     | Tree of Tree.t
     (* [_o i_ ___] *)
     | Find_tree of (context * key, tree option) fn
+    (* NOTE[adatario]: It seems like the key argument is missing.
+       Let's hope we don't have this in the raw actions trace.
+    *)
     | List of
         ( context * int option * int option,
           trees_with_contiguous_trackers (* not recording the steps *) )

--- a/src/trace/replay_actions.ml
+++ b/src/trace/replay_actions.ml
@@ -257,6 +257,10 @@ module V0 = struct
       | Add of (tree * key * value, tree) fn
       | Add_tree of (tree * key * tree, tree) fn
       | Remove of (tree * key, tree) fn
+      | Fold_start of (depth option * order) * tree * key
+      | Fold_step_enter of tree (* not recording step *)
+      | Fold_step_exit of tree
+      | Fold_end of int
     [@@deriving repr]
   end
 


### PR DESCRIPTION
This implements the `Tree.Fold_*` operations as replayable actions.

The logic for this was already present for handling `Tree.fold`, which is very similar.

Currently there are still some unimplemented actions (e.g. `List`).

Tested with a recording of a recording using the Tezos Lima protocol.