### PR TITLE
Fix GC stats recording

### DIFF
--- a/src/tools/replay/trace_replay.ml
+++ b/src/tools/replay/trace_replay.ml
@@ -618,6 +618,22 @@ struct
     val rs : warm_replay_state
   end) =
   struct
+    (** Custom event logging sink for recording GC start and stats.
+
+        Tezos uses a custom event logging framework (see
+        https://tezos.gitlab.io/user/logging.html) which is already
+        used to record GC start and end. This module implements an
+        event sink that listens for these GC events and records it to
+        the stats trace.
+
+        The reason for using the Tezos event logging framework instead
+        of using the `Stats_trace_recorder` is that the GC runs in a
+        forked process and waiting for it to return is tricky. Tezos
+        has properly setup hooks that wait for the GC to end and we
+        can just re-use them by plugging in to the event logging
+        framework.
+     *)
+
     type t = unit
 
     let uri_scheme = "context-replay"

--- a/src/trace/stats_trace_recorder.ml
+++ b/src/trace/stats_trace_recorder.ml
@@ -914,18 +914,9 @@ struct
     Lwt.return_unit
 
   let gc _index _hash =
-    report_gc_start ();
-    (* NOTE[adatario]: This is exactly what the hacked in GC stats in
-       `trace_replay.ml` does. I have no clue why there are so many
-       nested Lwt.return's.
-    *)
-    Lwt.return @@ fun _res ->
-    let latest_gc =
-      Irmin_pack_unix.Stats.((get ()).latest_gc |> Latest_gc.export)
-    in
-    match latest_gc with
-    | None -> assert false
-    | Some s -> Lwt.return @@ report_gc s
+    (* NOTE: this is a nop. GC start and stats are recorded by an
+       event sink in `Trace_replay` (see `Event_sink_for_gc`). *)
+    Lwt.return @@ fun _res -> Lwt.return_unit
 
   let split _index =
     (* TODO: record the split in the stats trace *)


### PR DESCRIPTION
GC start and stats are handled by a custom event sink in `Trace_replay`. There is no need to handle them in `Stats_trace_recorder`.